### PR TITLE
独立页面标签缺失

### DIFF
--- a/page.hbs
+++ b/page.hbs
@@ -40,7 +40,9 @@
       </footer>
     </section>
 
-
+  </div>
+ </article>
+</section>
 
 <div class="obox"> 
     <div id="disqus_thread">


### PR DESCRIPTION
![default](https://cloud.githubusercontent.com/assets/5889006/8144029/c258805c-11c9-11e5-8d3a-0442736be259.png)

修改[页面缩进](https://github.com/tcdw/optica-ghost/blob/a647e1f4aed37b50dc4b94477795ee356cda3b9d/page.hbs#L42)时出的错误。导致PJAX后出现多余的footer